### PR TITLE
Find a longer PV within a certain range if the best PV is too short.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -378,6 +378,10 @@ void MainThread::search() {
 
   // Check if there are threads with a better score than main thread
   Thread* bestThread = this;
+  Thread* longestPVThread = this;
+  const int minPlies = 6;
+  const int maxScoreDiff = 10;
+  const int minDepthDiff = 2;
   if (   !this->easyMovePlayed
       &&  Options["MultiPV"] == 1
       && !Limits.depth
@@ -387,7 +391,33 @@ void MainThread::search() {
       for (Thread* th : Threads)
           if (   th->completedDepth > bestThread->completedDepth
               && th->rootMoves[0].score > bestThread->rootMoves[0].score)
-              bestThread = th;
+              longestPVThread = bestThread = th;
+
+      if (bestThread->rootMoves[0].pv.size() < minPlies) {
+          for (Thread* th : Threads) {
+              // Look for the best thread that meets the minimum move criteria.
+              // Don't take a thread unless it's within the appropriate range of score
+              // eval. 
+              if (th->rootMoves[0].pv.size() <= longestPVThread->rootMoves[0].pv.size()) {
+                  continue;
+              }
+              bool possiblePVReplacement = true;
+              for (unsigned int i = 0; i < longestPVThread->rootMoves[0].pv.size(); ++i) {
+                  if (th->rootMoves[0].pv[i] != longestPVThread->rootMoves[0].pv[i]) {
+                      possiblePVReplacement = false;
+                      break;
+                  }
+              }
+              if (!possiblePVReplacement) {
+                  continue;
+              }
+              if (
+                     ((th->rootMoves[0].pv.size() >= minPlies)
+                  ||  (abs(th->rootMoves[0].score - longestPVThread->rootMoves[0].score) > maxScoreDiff))
+                  && ((th->completedDepth + minDepthDiff) >= longestPVThread->completedDepth))
+                  longestPVThread = th;
+          }
+      }
   }
 
   previousScore = bestThread->rootMoves[0].score;
@@ -395,6 +425,11 @@ void MainThread::search() {
   // Send new PV when needed
   if (bestThread != this)
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
+
+
+  // Send longer PV when needed
+  if (longestPVThread != bestThread)
+      sync_cout << UCI::pv(longestPVThread->rootPos, longestPVThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 
   // Best move could be MOVE_NONE when searching on a terminal position
   sync_cout << "bestmove " << UCI::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -380,7 +380,7 @@ void MainThread::search() {
   Thread* bestThread = this;
   Thread* longestPVThread = this;
   const int minPlies = 6;
-  const int maxScoreDiff = 15;
+  const int maxScoreDiff = 10;
   const int maxDepthDiff = 2;
   if (   !this->easyMovePlayed
       &&  Options["MultiPV"] == 1
@@ -430,6 +430,7 @@ void MainThread::search() {
                   // that is ALSO long enough but has a stronger eval/depth
                   if (
                           th->rootMoves[0].pv.size() >= minPlies
+                      && (bestThread->rootMoves[0].score - th->rootMoves[0].score) < maxScoreDiff
                       && (   th->rootMoves[0].score >= longestPVThread->rootMoves[0].score
                           || th->completedDepth >= longestPVThread->completedDepth)
                      )

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -418,7 +418,7 @@ void MainThread::search() {
                   // allow a weakening of score and depth to an absolute max of maxScoreDiff and maxDepthDiff
                   // compared to the bestThread.
                   if (   th->rootMoves[0].pv.size() >= longestPVThread->rootMoves[0].pv.size()
-                      && (bestThread->rootMoves[0].score - th->rootMoves[0].score) < maxScoreDiff
+                      && abs(bestThread->rootMoves[0].score - th->rootMoves[0].score) < maxScoreDiff
                       && (bestThread->completedDepth - th->completedDepth < maxDepthDiff))
                   {
                       longestPVThread = th;
@@ -430,7 +430,7 @@ void MainThread::search() {
                   // that is ALSO long enough but has a stronger eval/depth
                   if (
                           th->rootMoves[0].pv.size() >= minPlies
-                      && (bestThread->rootMoves[0].score - th->rootMoves[0].score) < maxScoreDiff
+                      && abs(bestThread->rootMoves[0].score - th->rootMoves[0].score) < maxScoreDiff
                       && (   th->rootMoves[0].score >= longestPVThread->rootMoves[0].score
                           || th->completedDepth >= longestPVThread->completedDepth)
                      )

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -380,7 +380,7 @@ void MainThread::search() {
   Thread* bestThread = this;
   Thread* longestPVThread = this;
   const int minPlies = 6;
-  const int maxScoreDiff = 10;
+  const int maxScoreDiff = 15;
   const int maxDepthDiff = 2;
   if (   !this->easyMovePlayed
       &&  Options["MultiPV"] == 1


### PR DESCRIPTION
If the best chosen PV is shorter than a given number of plies, look for
a better PV to use which is within a certain score and depth range.
Ensure that the longer PV uses all of the same moves from the chosen PV.

Send it to the GUI after the chosen PV is sent.

This likely needs a bit of tuning and careful consideration, but it
should find a reasonable PV with perhaps a bit of loss of strength.

It probably needs to be heavily tested on the games that show the small
PVs to ensure that the chosen PV is worth showing.