### PR TITLE
Fix build on ARMv7 Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -169,6 +169,9 @@ ifeq ($(COMP),gcc)
 			CXXFLAGS += -m$(bits)
 			LDFLAGS += -m$(bits)
 		endif
+		ifeq ($(OS),GNU/Linux)
+			LDFLAGS += -latomic
+		endif
 	endif
 
 	ifneq ($(KERNEL),Darwin)

--- a/src/Makefile
+++ b/src/Makefile
@@ -169,9 +169,6 @@ ifeq ($(COMP),gcc)
 			CXXFLAGS += -m$(bits)
 			LDFLAGS += -m$(bits)
 		endif
-	else
-		CXXFLAGS += -m$(bits)
-		LDFLAGS += -m$(bits)
 	endif
 
 	ifneq ($(KERNEL),Darwin)


### PR DESCRIPTION
Combined with https://github.com/niklasf/fishnet/pull/118, this allows `build_stockfish.sh` to work on Pis.

```
~/Projects/fishnet $ file stockfish-armv7
stockfish-armv7: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, BuildID[sha1]=cc9a1ef646fa60f8834cd0fe912fa5d575438be0, not stripped
```